### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Amazon Redshift is a fast, fully managed, petabyte-scale data warehouse solution
 ## Labs
 |# |Lab Name |Lab Description |
 |---- |---- | ----|
-|1 |[Creating Redshift Clusters](https://redshift-immersion.workshop.aws/en/lab1.html) |Cluster setup and connectivity with SQL Workbench/J |
-|2 |[Data Loading](https://redshift-immersion.workshop.aws/en/lab2.html) |Table creation, data load, and table maintenance |
-|3 |[Table Design & Query Tuning](https://redshift-immersion.workshop.aws/en/lab3.html) |Setting distribution and sort keys, deep copy, explain plans, system table queries |
-|4 |[Modernize Your Data Warehouse with Amazon Redshift Spectrum](https://redshift-immersion.workshop.aws/en/lab4.html) |Query petabytes of data in your data warehouse and exabytes of data in your S3 data lake, using Redshift Spectrum |
-|5 |[Amazon Redshift Spectrum Query Tuning](https://redshift-immersion.workshop.aws/en/lab5.html) | Diagnose Redshift Spectrum query performance and optimize by leveraging partitions, optimizing storage, and predicate pushdown.|
-|6 |[Query Aurora PostgreSQL using Federation](https://redshift-immersion.workshop.aws/en/lab6.html) |Leverage the Federation capability to JOIN Amazon Redshift AND Amazon RDS PostgreSQL. |
-|7 | [Amazon Redshift Operations](https://redshift-immersion.workshop.aws/en/lab7.html) | Step through some common operations a Redshift Administrator may have to do to maintain their Redhshift environment including Event Subscriptions, Cluster Encryption, Cross Region Snapshots, and Elastic Resize |
-|8 | [Querying Nested JSON](https://redshift-immersion.workshop.aws/en/lab8.html)| Query Nested JSON datatypes (array, struct, map) and load nested data types into flattened structures. |
+|1 |[Creating Redshift Clusters](https://redshift-immersion.workshop.aws/lab1.html) |Cluster setup and connectivity with SQL Workbench/J |
+|2 |[Data Loading](https://redshift-immersion.workshop.aws/lab2.html) |Table creation, data load, and table maintenance |
+|3 |[Table Design & Query Tuning](https://redshift-immersion.workshop.aws/lab3.html) |Setting distribution and sort keys, deep copy, explain plans, system table queries |
+|4 |[Modernize Your Data Warehouse with Amazon Redshift Spectrum](https://redshift-immersion.workshop.aws/lab4.html) |Query petabytes of data in your data warehouse and exabytes of data in your S3 data lake, using Redshift Spectrum |
+|5 |[Amazon Redshift Spectrum Query Tuning](https://redshift-immersion.workshop.aws/lab5.html) | Diagnose Redshift Spectrum query performance and optimize by leveraging partitions, optimizing storage, and predicate pushdown.|
+|6 |[Query Aurora PostgreSQL using Federation](https://redshift-immersion.workshop.aws/lab6.html) |Leverage the Federation capability to JOIN Amazon Redshift AND Amazon RDS PostgreSQL. |
+|7 | [Amazon Redshift Operations](https://redshift-immersion.workshop.aws/lab7.html) | Step through some common operations a Redshift Administrator may have to do to maintain their Redhshift environment including Event Subscriptions, Cluster Encryption, Cross Region Snapshots, and Elastic Resize |
+|8 | [Querying Nested JSON](https://redshift-immersion.workshop.aws/lab8.html)| Query Nested JSON datatypes (array, struct, map) and load nested data types into flattened structures. |
 
 ## License Summary
 


### PR DESCRIPTION
I just noticed that links to immersion day workshop does not support `/en/` in the URL, i've updated `README.md` links accordingly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
